### PR TITLE
Update dependency requirements

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -12,7 +12,8 @@
         "Development Status :: 4 - Beta"
     ],
     "install_requires": [
-        "aiida-quantumespresso>=3.0.0"
+        "aiida-core>=1.0.0b6,<2.0",
+        "aiida-quantumespresso>=3.0.0a5,<4.0"
     ],
     "entry_points": {
         "aiida.calculations": [


### PR DESCRIPTION
Fixes #7 

Set explicit version for `aiida-core`, which is necessary for the
registry to know what version it is compatible. Otherwise it will have
to infer it indirectly from `aiida-quantumespresso`. The latter's
requirement is also updated to the correct version.